### PR TITLE
Fix FHIR response parser for schemas with groups

### DIFF
--- a/src/resp-mapper.ts
+++ b/src/resp-mapper.ts
@@ -87,7 +87,7 @@ const formValueToFhirAnswer = (
           answer.push({
             [propertyName]: {
               code: formDataValue,
-              display: enumNames[valueIndex],
+              display: enumNames[valueIndex] || null,
             },
           });
         } else {

--- a/src/resp-mapper.ts
+++ b/src/resp-mapper.ts
@@ -35,35 +35,37 @@ export const FhirJsonResp = (
 };
 
 // https://stackoverflow.com/questions/15523514/find-by-key-deep-in-a-nested-array
-const getObject = function(theObject: Object | Object[], theProperty: string) {
+const getObject = function(theObject: Object | Object[], theProperty: string, returnObjects?: boolean) {
   var result = null;
   if (theObject instanceof Array) {
     for (var i = 0; i < theObject.length; i++) {
-      result = getObject(theObject[i], theProperty);
+      // end of the road of value is a string
+      if (typeof theObject[i] === "string") {
+        break;
+      }
+
+      result = getObject(theObject[i], theProperty, returnObjects);
       if (result) {
         break;
       }
     }
   } else {
     for (var prop in theObject) {
-      //console.log(prop + ': ' + theObject[prop]);
-      if (prop === theProperty) {
-        if (theObject[prop] instanceof Object) {
-        } else {
-          return theObject[prop];
-        }
+      if (prop === theProperty && (!(theObject[prop] instanceof Object) || returnObjects) ) {
+        return theObject[prop];
       }
       if (
         theObject[prop] instanceof Object ||
         theObject[prop] instanceof Array
       ) {
-        result = getObject(theObject[prop], theProperty);
+        result = getObject(theObject[prop], theProperty, returnObjects);
         if (result) {
           break;
         }
       }
     }
   }
+
   return result;
 };
 
@@ -72,13 +74,14 @@ const formValueToFhirAnswer = (
   fhirElement: R4.IQuestionnaireResponse_Answer,
   jsonSchema: FhirForm['schema'],
   linkId: string
-) =>
+) => 
   supportedValueTypes.reduce(
     (answer: Array<{ [x: string]: any }>, propertyName) => {
       if (fhirElement && fhirElement.hasOwnProperty(propertyName)) {
-        const enumNames = jsonSchema.properties[linkId]?.enumNames;
+        const linkProperties = getObject(jsonSchema.properties, linkId, true)      
+        const enumNames = linkProperties?.enumNames;
         if (enumNames) {
-          const valueIndex = jsonSchema.properties[linkId].enum.indexOf(
+          const valueIndex = linkProperties.enum.indexOf(
             formDataValue
           );
           answer.push({
@@ -94,6 +97,6 @@ const formValueToFhirAnswer = (
         }
       }
       return answer;
-    },
+    }, 
     []
-  );
+);

--- a/test/resp.test.ts
+++ b/test/resp.test.ts
@@ -11,7 +11,7 @@ const formData =
   '{"1": true,"2": {"2.1": "Male", "2.2": "12/12/2020", "2.3": "Canada", "2.4": "Married"},"3": {"3.1": true,"3.2": true}}';
 
 const parsedResponse: R4.IQuestionnaireResponse = JSON.parse(
-  '      {"resourceType":"QuestionnaireResponse","item":[{"linkId":"1","text":"Do you have allergies?","answer":[{"valueBoolean":true}]},{"linkId":"sex","text":"Sex","answer":[{"valueCoding":null}]},{"linkId":"2.2","text":"What is your date of birth?","answer":[{"valueDate":"12/12/2020"}]},{"linkId":"2.3","text":"What is your country of birth?","answer":[{"valueString":"Canada"}]},{"linkId":"2.4","text":"What is your marital status?","answer":[{"valueString":"Married"}]},{"linkId":"3.1","text":"Do you smoke?","answer":[{"valueBoolean":true}]},{"linkId":"3.2","text":"Do you drink alchohol?","answer":[{"valueBoolean":true}]}],"status":"in-progress"}'
+  '      {"resourceType":"QuestionnaireResponse","item":[{"linkId":"1","text":"Do you have allergies?","answer":[{"valueBoolean":true}]},{"linkId":"sex","text":"Sex","answer":[{"valueCoding":{"code":null,"display":null}}]},{"linkId":"2.2","text":"What is your date of birth?","answer":[{"valueDate":"12/12/2020"}]},{"linkId":"2.3","text":"What is your country of birth?","answer":[{"valueString":"Canada"}]},{"linkId":"2.4","text":"What is your marital status?","answer":[{"valueString":"Married"}]},{"linkId":"3.1","text":"Do you smoke?","answer":[{"valueBoolean":true}]},{"linkId":"3.2","text":"Do you drink alchohol?","answer":[{"valueBoolean":true}]}],"status":"in-progress"}'
 );
 
 describe('map', () => {


### PR DESCRIPTION
Before this fix, the fhir response parser would be unable to find properties matching a `linkId` when doing a lookup on a schema for questionnaire with groups.

0.8.1 🚀 