### PR TITLE
Fix range input value type convertion

### DIFF
--- a/src/ques-mapper.ts
+++ b/src/ques-mapper.ts
@@ -154,7 +154,7 @@ const ProcessQuestionnaireItem = (item: R4.IQuestionnaire_Item) => {
 };
 
 const GetOptions = (item: R4.IQuestionnaire_Item) => {
-  let enumOptions: string[] = [];
+  let enumOptions: (string|number)[] = [];
   let enumNames: string[] = [];
 
   if (typeof item.answerOption !== 'undefined') {
@@ -162,7 +162,9 @@ const GetOptions = (item: R4.IQuestionnaire_Item) => {
       let code =
         typeof choice.valueCoding === 'undefined'
           ? ''
-          : choice.valueCoding.code?.toString();
+          : GetControlType(item) === 'integer' 
+            ? choice.valueCoding.code && parseInt(choice.valueCoding.code)
+            : choice.valueCoding.code?.toString();
 
       enumOptions.push(typeof code === 'undefined' ? '' : code);
 
@@ -264,7 +266,7 @@ const GetControlType = (item: R4.IQuestionnaire_Item) => {
     }
 
     if (coding?.code === EXTENSION_SLIDER) {
-      return 'number'
+      return 'integer'
     }
   }
 

--- a/src/resp-mapper.ts
+++ b/src/resp-mapper.ts
@@ -86,7 +86,7 @@ const formValueToFhirAnswer = (
           );
           answer.push({
             [propertyName]: {
-              code: formDataValue,
+              code: `${formDataValue}`,
               display: enumNames[valueIndex] || null,
             },
           });

--- a/src/resp-mapper.ts
+++ b/src/resp-mapper.ts
@@ -86,7 +86,7 @@ const formValueToFhirAnswer = (
           );
           answer.push({
             [propertyName]: {
-              code: `${formDataValue}`,
+              code: formDataValue !== null && formDataValue !== void 0 ? `${formDataValue}` : formDataValue,
               display: enumNames[valueIndex] || null,
             },
           });


### PR DESCRIPTION
Range inputs need to have their enum options set as numbers, otherwise the form validation will fail due to type mismatch.

Basically, the form would spit out the range value as a number, but the enum only had strings as valid inputs, so it would fail validation with an error.